### PR TITLE
clang-tidy/format cleanups

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,6 @@
+BasedOnStyle: WebKit
+AlignAfterOpenBracket: Align
+AlignConsecutiveMacros: true
+AlignTrailingComments: true
+BreakBeforeBinaryOperators: NonAssignment
+DerivePointerAlignment: true

--- a/afalg.c
+++ b/afalg.c
@@ -1084,8 +1084,8 @@ static void afalg_select_all_ciphers(int *cipher_list, int include_ecb)
         if (include_ecb ||
            ((cipher_data[i].flags & EVP_CIPH_MODE) != EVP_CIPH_ECB_MODE))
             cipher_list[i] = 1;
-       else
-           cipher_list[i] = 0;
+        else
+            cipher_list[i] = 0;
     }
 }
 

--- a/afalg.c
+++ b/afalg.c
@@ -29,16 +29,16 @@
 static size_t zc_maxsize, pagemask;
 #endif
 
+#include <asm/byteorder.h>
+#include <asm/types.h>
+#include <assert.h>
+#include <fcntl.h>
 #include <string.h>
+#include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <fcntl.h>
-#include <sys/ioctl.h>
 #include <unistd.h>
-#include <assert.h>
-#include <asm/byteorder.h>
-#include <asm/types.h>
 #ifndef AFALG_NO_CRYPTOUSER
 # include <linux/cryptouser.h>
 #elif !defined(CRYPTO_MAX_NAME)
@@ -49,9 +49,9 @@ static size_t zc_maxsize, pagemask;
 #include <linux/rtnetlink.h>
 
 #include <openssl/conf.h>
-#include <openssl/evp.h>
-#include <openssl/err.h>
 #include <openssl/engine.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
 #include <openssl/objects.h>
 
 /* linux/crypto.h is not public, so we must define the type and masks here,

--- a/afalg.c
+++ b/afalg.c
@@ -224,7 +224,7 @@ static int prepare_afalg_alg_list(void)
         if ((msg_len = recvmsg(nlfd, &msg, 0)) <= 0) {
             if (errno == EINTR || errno == EAGAIN)
                 continue;
-            else if (msg_len == 0)
+            if (msg_len == 0)
                 perror("Nelink error: no data");
             else
                 perror("Nelink error: netlink receive error");


### PR DESCRIPTION
Description:
------------
clang-tidy/format stuff

git clang-format HEAD~1 can be used to run it against the current commit only.

clang-format -i afalg.c will apply all the changes to the file.

Note that these changes are purely cosmetic.